### PR TITLE
Change package.json[main] to 'src/attempt.js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Easily running a massive amount of tests with different arguments",
   "author": "Espen Henriksen",
   "license": "MIT",
-  "main": "lib/attempt.js",
+  "main": "src/attempt.js",
   "scripts": {
     "build": "babel src --out-dir lib",
     "test": "jest --coverage"


### PR DESCRIPTION
I think you changed the folder name and forgot to change the `main` value in `package.json`.  This is causing `Error: Cannot find module 'attempt-test'` problems on my project.  

Seems like a sweet package, by the way; thanks for publishing it.  